### PR TITLE
feat: Avoid bootstrapping the same CDK environment in parallel

### DIFF
--- a/core-aws/package.json
+++ b/core-aws/package.json
@@ -17,7 +17,8 @@
     "@aws-sdk/client-sts": "^3.81.0",
     "async-lock": "^1.3.1",
     "aws-cdk": "^2.22.0",
-    "aws-cdk-lib": "^2.22.0"
+    "aws-cdk-lib": "^2.22.0",
+    "uni-global": "^1.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.3.1",

--- a/core-aws/package.json
+++ b/core-aws/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc",
-    "build-fast": "esbuild-node-tsc"
+    "build-fast": "esbuild-node-tsc",
+    "test": "ts-mocha test/**/*.test.ts"
   },
   "peerDependencies": {
     "@serverless-components/core": "^0.0.1"
@@ -14,7 +15,19 @@
   "dependencies": {
     "@aws-sdk/client-cloudformation": "^3.81.0",
     "@aws-sdk/client-sts": "^3.81.0",
+    "async-lock": "^1.3.1",
     "aws-cdk": "^2.22.0",
     "aws-cdk-lib": "^2.22.0"
+  },
+  "devDependencies": {
+    "@types/chai": "^4.3.1",
+    "@types/mocha": "^9.1.1",
+    "@types/sinon-chai": "^3.2.8",
+    "chai": "^4.3.6",
+    "mocha": "^10.0.0",
+    "proxyquire": "^2.1.3",
+    "sinon": "^14.0.0",
+    "sinon-chai": "^3.7.0",
+    "ts-mocha": "^10.0.0"
   }
 }

--- a/core-aws/test/Cdk.test.ts
+++ b/core-aws/test/Cdk.test.ts
@@ -1,0 +1,97 @@
+import { ComponentContext } from '@serverless-components/core';
+import proxyquire from 'proxyquire';
+import { SinonSpy, spy } from 'sinon';
+import { App, Stack } from 'aws-cdk-lib';
+import { expect } from 'chai';
+import { Cdk } from '../src';
+import FakeComponentContext from './FakeComponentContext';
+
+describe('Cdk', () => {
+  it('bootstraps the AWS CDK automatically', async () => {
+    const [cdk, spawnStub] = mockCdk(new FakeComponentContext());
+
+    const app = new App();
+    new Stack(app, 'stack-name');
+    await cdk.deploy(app);
+
+    expect(spawnStub.callCount).to.be.greaterThanOrEqual(1);
+    expect(spawnStub.getCall(0).args[0]).to.equal('cdk');
+    expect(spawnStub.getCall(0).args[1][0]).to.equal('bootstrap');
+  });
+
+  it('does not bootstrap the AWS CDK in parallel to avoid race conditions', async () => {
+    let isBootstrapping = false;
+    let raceCondition = false;
+
+    // Component A
+    const [cdkA, spawnStubA] = mockCdk(new FakeComponentContext(), async (command, args) => {
+      if (args[0] !== 'bootstrap') return 0; // other commands like `deploy` should resolve instantly
+      isBootstrapping = true;
+      await sleep(100);
+      isBootstrapping = false;
+      return 0;
+    });
+    // Component B
+    const [cdkB, spawnStubB] = mockCdk(new FakeComponentContext(), async (command, args) => {
+      if (args[0] !== 'bootstrap') return 0; // other commands like `deploy` should resolve instantly
+      // Wait a little before starting so that cdkA has time to set `isBootstrapping = true`
+      await sleep(20);
+      if (isBootstrapping) {
+        // If we reach this point we have a bug (we have a race condition)
+        raceCondition = true;
+      }
+      return 0;
+    });
+
+    const app = new App();
+    new Stack(app, 'stack-name');
+    await Promise.all([cdkA.deploy(app), cdkB.deploy(app)]);
+
+    expect(raceCondition).to.be.equal(false);
+    // Also make sure that both components actually ran `cdk bootstrap`
+    expect(spawnStubA.callCount).to.be.greaterThanOrEqual(1);
+    expect(spawnStubA.getCall(0).args[0]).to.equal('cdk');
+    expect(spawnStubA.getCall(0).args[1][0]).to.equal('bootstrap');
+    expect(spawnStubB.callCount).to.be.greaterThanOrEqual(1);
+    expect(spawnStubB.getCall(0).args[0]).to.equal('cdk');
+    expect(spawnStubB.getCall(0).args[1][0]).to.equal('bootstrap');
+  });
+});
+
+/**
+ * @param componentContext
+ * @param onSpawn Optional: behavior we want to execute when the CLK CLI runs.
+ */
+function mockCdk(
+  componentContext: ComponentContext,
+  onSpawn?: (command: string, args: string[]) => number | Promise<number>
+): [Cdk, SinonSpy] {
+  const spawnStub = spy((command: string, args: string[]) => {
+    return {
+      on: async (arg, cb) => {
+        if (arg === 'close') {
+          const exitCode = onSpawn ? await onSpawn(command, args) : 0;
+          cb(exitCode);
+        }
+      },
+      stdout: {
+        on: (arg, cb) => {
+          if (arg === 'data') cb('This is the CDK CLI output');
+        },
+      },
+    };
+  });
+  const MockedCdk = proxyquire('../src/Cdk', {
+    child_process: { spawn: spawnStub },
+  }).default;
+
+  const cdk = new MockedCdk(componentContext, 'stack-name', 'us-east-1', {
+    region: 'us-east-1',
+  }) as Cdk;
+
+  return [cdk, spawnStub];
+}
+
+async function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/core-aws/test/FakeComponentContext.ts
+++ b/core-aws/test/FakeComponentContext.ts
@@ -1,0 +1,44 @@
+import { ComponentContext } from '@serverless-components/core';
+
+export default class FakeComponentContext implements ComponentContext {
+  stage = 'dev';
+  outputs: Record<string, any>;
+  state: Record<string, any>;
+
+  constructor(state = {}, outputs = {}) {
+    this.state = state;
+    this.outputs = outputs;
+  }
+
+  writeText(message: string, namespace?: string[]): void {
+    // no logs
+  }
+
+  logError(error: string | Error, namespace?: string[]): void {
+    // no logs
+  }
+
+  logVerbose(message: string, namespace?: string[]): void {
+    // no logs
+  }
+
+  async save(): Promise<void> {
+    // ok
+  }
+
+  async updateOutputs(outputs: Record<string, any>): Promise<void> {
+    this.outputs = outputs;
+  }
+
+  startProgress(text: string): void {
+    // no logs
+  }
+
+  successProgress(text: string): void {
+    // no logs
+  }
+
+  updateProgress(text: string): void {
+    // no logs
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es5",
+    "esModuleInterop": true,
     "sourceMap": true,
     "allowJs": true,
     // Type checking for JS files too


### PR DESCRIPTION
Before: component A and component B would run `cdk bootstrap` for the same account/region in parallel.

After: component A and component B do not run `cdk bootstrap` in parallel (it is sequential).

That go me started with writing tests. I tried to use an approach as close as possible to what already exists in Compose. Also I set up mocha with `ts-node` integrated, so we don't have to worry about TypeScript compilation at all (not even `npm run watch`).

Running `npm run test` at the root of the repo works too.

Here's an example of a CLI (verbose) output with such a scenario (I added extra lines to make it more readable):

```
❯ sls deploy --verbose

Deploying to stage dev
compose-website › waiting
compose-website-2 › waiting
compose-website › building
compose-website-2 › building
compose-website › deploying
compose-website-2 › deploying


compose-website › Bootstrapping the AWS CDK in "aws://416566615250/us-east-1"
compose-website › Running "cdk bootstrap aws://416566615250/us-east-1 --toolkit-stack-name serverless-cdk-toolkit --qualifier serverless"
compose-website › ⏳  Bootstrapping environment aws://416566615250/us-east-1...
compose-website › Trusted accounts for deployment: (none)
compose-website › Trusted accounts for lookup: (none)
compose-website › Using default execution policy of 'arn:aws:iam::aws:policy/AdministratorAccess'. Pass '--cloudformation-execution-policies' to customize.
compose-website › ✅  Environment aws://416566615250/us-east-1 bootstrapped (no changes).


compose-website-2 › Bootstrapping the AWS CDK in "aws://416566615250/us-east-1"
compose-website-2 › Running "cdk bootstrap aws://416566615250/us-east-1 --toolkit-stack-name serverless-cdk-toolkit --qualifier serverless"
compose-website › Packaging compose-website-dev
compose-website › Nothing to deploy, the stack is up to date
compose-website › uploading assets
compose-website › Skipped uploading 1 unchanged files
compose-website › no changes
compose-website-2 › ⏳  Bootstrapping environment aws://416566615250/us-east-1...
compose-website-2 › Trusted accounts for deployment: (none)
compose-website-2 › Trusted accounts for lookup: (none)
compose-website-2 › Using default execution policy of 'arn:aws:iam::aws:policy/AdministratorAccess'. Pass '--cloudformation-execution-policies' to customize.
compose-website-2 › ✅  Environment aws://416566615250/us-east-1 bootstrapped (no changes).

compose-website-2 › Packaging compose-website-2-dev
...
```