### PR TITLE
fix: Unnecessary `async` wrapping

### DIFF
--- a/utils-aws/src/utils/default-provider.js
+++ b/utils-aws/src/utils/default-provider.js
@@ -47,7 +47,7 @@ const remoteProvider = require('./remote-provider');
  * @see {@link fromContainerMetadata}   The function used to source credentials from the
  *                              ECS Container Metadata Service
  */
-async function defaultProvider(init) {
+function defaultProvider(init) {
   return memoize(
     chain(
       // Change the logic to not skip `fromEnv` when process.env.AWS_PROFILE is present

--- a/utils-aws/src/utils/from-node-provider-chain.js
+++ b/utils-aws/src/utils/from-node-provider-chain.js
@@ -33,7 +33,7 @@ const defaultProvider = require('./default-provider');
  * })
  * ```
  */
-async function fromNodeProviderChain(init) {
+function fromNodeProviderChain(init) {
   // We needed to swap the `defaultProvider` implementation for the one that was adjusted by us in `./default-provider`
   return defaultProvider({
     ...init,

--- a/utils-aws/src/utils/remote-provider.js
+++ b/utils-aws/src/utils/remote-provider.js
@@ -16,7 +16,7 @@ const {
 const ENV_IMDS_DISABLED = 'AWS_EC2_METADATA_DISABLED';
 
 // We needed to copy it as-is as it is internal logic of `@aws-sdk/credential-provider-node` package
-async function remoteProvider(init) {
+function remoteProvider(init) {
   if (process.env[ENV_CMDS_RELATIVE_URI] || process.env[ENV_CMDS_FULL_URI]) {
     return fromContainerMetadata(init);
   }


### PR DESCRIPTION
It caused an issue when `remoteProvider` should be called (I've spotted it when testing remote state bucket provisioning)